### PR TITLE
Fix acquiring the TKK token for google translate

### DIFF
--- a/googletrans/gtoken.py
+++ b/googletrans/gtoken.py
@@ -40,6 +40,8 @@ class TokenAcquirer(object):
 
     RE_TKK = re.compile(r'TKK=eval\(\'\(\(function\(\)\{(.+?)\}\)\(\)\)\'\);',
                         re.DOTALL)
+    RE_RAWTKK = re.compile(r'TKK=\'([^\']*)\';',
+                        re.DOTALL)
 
     def __init__(self, tkk='0', session=None, host='translate.google.com'):
         self.session = session or requests.Session()
@@ -55,6 +57,12 @@ class TokenAcquirer(object):
             return
 
         r = self.session.get(self.host, verify=False)
+
+        rawtkk = self.RE_RAWTKK.search(r.text)
+        if rawtkk is not None:
+            self.tkk = rawtkk.group(1)
+            return
+
         # this will be the same as python code after stripping out a reserved word 'var'
         code = unicode(self.RE_TKK.search(r.text).group(1)).replace('var ', '')
         # unescape special ascii characters such like a \x3d(=)


### PR DESCRIPTION
py-googletranslate used to have to extract and calculate the token but it seems the translate api changed to just give out the token.
In the event that it changes back to the old method I check if the regex actually matched anything and use the old code if necessary.